### PR TITLE
Set up Drizzle ORM and BetterAuth integration

### DIFF
--- a/backend/drizzle.config.ts
+++ b/backend/drizzle.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'drizzle-kit';
+
+export default {
+  schema: './src/drizzle/schema/index.ts',
+  out: './src/drizzle/migrations',
+  driver: 'd1',
+  dbCredentials: {
+    wranglerConfigPath: './wrangler.toml',
+    dbName: 'subxiv_db',
+  },
+} satisfies Config;

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,12 +8,19 @@
     "build": "wrangler deploy --dry-run",
     "deploy": "wrangler deploy",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "wrangler d1 migrations apply subxiv_db --local",
+    "db:setup": "node scripts/setup-local-db.js"
   },
   "dependencies": {
     "hono": "^3.5.0",
     "drizzle-orm": "^0.28.6",
-    "@cloudflare/workers-types": "^4.20230821.0"
+    "@cloudflare/workers-types": "^4.20230821.0",
+    "@paralleldrive/cuid2": "^2.2.2",
+    "better-auth": "^1.2.4",
+    "zod": "^3.22.4",
+    "@hono/zod-validator": "^0.1.11"
   },
   "devDependencies": {
     "drizzle-kit": "^0.19.13",

--- a/backend/scripts/setup-local-db.js
+++ b/backend/scripts/setup-local-db.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/**
+ * This script creates a local D1 database for development
+ */
+
+const { execSync } = require('child_process');
+
+// Run wrangler commands to set up the local D1 database
+try {
+  console.log('Creating local D1 database...');
+  execSync('wrangler d1 create subxiv_db --local', { stdio: 'inherit' });
+  
+  console.log('Generating migrations...');
+  execSync('npm run db:generate', { stdio: 'inherit' });
+  
+  console.log('Applying migrations...');
+  execSync('npm run db:migrate', { stdio: 'inherit' });
+  
+  console.log('Local database setup complete!');
+} catch (error) {
+  console.error('Error setting up local database:', error.message);
+  process.exit(1);
+}

--- a/backend/src/drizzle/db.ts
+++ b/backend/src/drizzle/db.ts
@@ -1,0 +1,8 @@
+import { drizzle } from 'drizzle-orm/d1';
+import * as schema from './schema';
+
+export function createDb(dbInstance: D1Database) {
+  return drizzle(dbInstance, { schema });
+}
+
+export type Database = ReturnType<typeof createDb>;

--- a/backend/src/drizzle/schema/index.ts
+++ b/backend/src/drizzle/schema/index.ts
@@ -1,0 +1,3 @@
+export * from './users';
+export * from './interests';
+export * from './papers';

--- a/backend/src/drizzle/schema/interests.ts
+++ b/backend/src/drizzle/schema/interests.ts
@@ -1,0 +1,20 @@
+import { sqliteTable, text, integer, json } from 'drizzle-orm/sqlite-core';
+import { createId } from '@paralleldrive/cuid2';
+import { users } from './users';
+
+export const userInterests = sqliteTable('user_interests', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  userId: text('user_id').notNull().references(() => users.id),
+  name: text('name').notNull(),
+  prompt: text('prompt').notNull(),
+  categories: json('categories').$type<string[]>(),
+  keywords: json('keywords').$type<string[]>(),
+  excludedKeywords: json('excluded_keywords').$type<string[]>(),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+});
+
+export type UserInterest = typeof userInterests.$inferSelect;
+export type NewUserInterest = typeof userInterests.$inferInsert;

--- a/backend/src/drizzle/schema/papers.ts
+++ b/backend/src/drizzle/schema/papers.ts
@@ -1,0 +1,33 @@
+import { sqliteTable, text, integer, json } from 'drizzle-orm/sqlite-core';
+import { createId } from '@paralleldrive/cuid2';
+
+export const papers = sqliteTable('papers', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  arxivId: text('arxiv_id').notNull().unique(),
+  title: text('title').notNull(),
+  abstract: text('abstract').notNull(),
+  authors: json('authors').$type<string[]>(),
+  categories: json('categories').$type<string[]>(),
+  publishedAt: integer('published_at', { mode: 'timestamp' }),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }),
+  pdfUrl: text('pdf_url'),
+  embeddings: json('embeddings').$type<number[]>(),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+});
+
+export const userSavedPapers = sqliteTable('user_saved_papers', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  userId: text('user_id').notNull(),
+  paperId: text('paper_id').notNull().references(() => papers.id),
+  interestId: text('interest_id'),
+  notes: text('notes'),
+  tags: json('tags').$type<string[]>(),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+});
+
+export type Paper = typeof papers.$inferSelect;
+export type NewPaper = typeof papers.$inferInsert;
+export type UserSavedPaper = typeof userSavedPapers.$inferSelect;
+export type NewUserSavedPaper = typeof userSavedPapers.$inferInsert;

--- a/backend/src/drizzle/schema/users.ts
+++ b/backend/src/drizzle/schema/users.ts
@@ -1,0 +1,26 @@
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { createId } from '@paralleldrive/cuid2';
+
+export const users = sqliteTable('users', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  email: text('email').notNull().unique(),
+  name: text('name'),
+  authId: text('auth_id').notNull().unique(),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+});
+
+export const sessions = sqliteTable('sessions', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  userId: text('user_id').notNull().references(() => users.id),
+  expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .$defaultFn(() => new Date()),
+});
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+export type Session = typeof sessions.$inferSelect;
+export type NewSession = typeof sessions.$inferInsert;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,8 +1,18 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { createAuthRoutes, createAuthMiddleware } from './modules/auth';
+import { createDb } from './drizzle/db';
 
 // Create the main Hono app
-const app = new Hono();
+const app = new Hono<{
+  Bindings: {
+    DB: D1Database;
+  },
+  Variables: {
+    user: any | null;
+    db: any;
+  }
+}>();
 
 // Add CORS middleware
 app.use('*', cors({
@@ -11,7 +21,19 @@ app.use('*', cors({
   allowHeaders: ['Content-Type', 'Authorization'],
   exposeHeaders: ['Content-Length'],
   maxAge: 86400,
+  credentials: true,
 }));
+
+// Add DB and Auth middleware
+app.use('*', async (c, next) => {
+  // Create DB instance
+  const db = createDb(c.env.DB);
+  c.set('db', db);
+  
+  // Add auth middleware
+  const authMiddleware = createAuthMiddleware(db);
+  await authMiddleware(c, next);
+});
 
 // Define API routes
 app.get('/', (c) => {
@@ -26,6 +48,9 @@ app.get('/', (c) => {
 app.get('/health', (c) => {
   return c.json({ status: 'ok' });
 });
+
+// Auth routes
+app.route('/auth', createAuthRoutes(createDb(app.env.DB)));
 
 // Export the app for Cloudflare Workers
 export default app;

--- a/backend/src/modules/auth/auth.ts
+++ b/backend/src/modules/auth/auth.ts
@@ -1,0 +1,80 @@
+import { betterAuth } from 'better-auth';
+import { createDb, type Database } from '../../drizzle/db';
+import { users, sessions } from '../../drizzle/schema';
+import { createId } from '@paralleldrive/cuid2';
+
+// Create a custom adapter for BetterAuth to use with Drizzle ORM
+export const createBetterAuthAdapter = (db: Database) => {
+  return {
+    async createUser({ email, id: authId, name }) {
+      const newUser = await db.insert(users).values({
+        email,
+        authId,
+        name: name || '',
+      }).returning().get();
+      
+      return newUser;
+    },
+    
+    async getUserByEmail(email: string) {
+      return await db.query.users.findFirst({
+        where: (users, { eq }) => eq(users.email, email)
+      });
+    },
+    
+    async getUserById(id: string) {
+      return await db.query.users.findFirst({
+        where: (users, { eq }) => eq(users.id, id)
+      });
+    },
+    
+    async getUserByAuthId(authId: string) {
+      return await db.query.users.findFirst({
+        where: (users, { eq }) => eq(users.authId, authId)
+      });
+    },
+    
+    async createSession({ userId, expiresAt }) {
+      const session = await db.insert(sessions).values({
+        userId,
+        expiresAt: new Date(expiresAt),
+      }).returning().get();
+      
+      return session;
+    },
+    
+    async getSessionById(id: string) {
+      return await db.query.sessions.findFirst({
+        where: (sessions, { eq }) => eq(sessions.id, id)
+      });
+    },
+    
+    async deleteSession(id: string) {
+      await db.delete(sessions).where(sessions.id === id);
+    },
+    
+    async deleteUserSessions(userId: string) {
+      await db.delete(sessions).where(sessions.userId === userId);
+    }
+  };
+};
+
+// Initialize BetterAuth
+export function initAuth(db: Database) {
+  const adapter = createBetterAuthAdapter(db);
+  
+  const auth = betterAuth({
+    adapter,
+    sessionExpiresIn: 30 * 24 * 60 * 60, // 30 days in seconds
+    generateId: () => createId(),
+    cookies: {
+      secure: true,
+      sameSite: 'lax',
+    },
+  });
+  
+  return auth;
+}
+
+// Type for Auth instance
+export type Auth = ReturnType<typeof initAuth>;

--- a/backend/src/modules/auth/index.ts
+++ b/backend/src/modules/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './auth';
+export * from './routes';
+export * from './middleware';

--- a/backend/src/modules/auth/middleware.ts
+++ b/backend/src/modules/auth/middleware.ts
@@ -1,0 +1,51 @@
+import { Context, MiddlewareHandler } from 'hono';
+import { initAuth } from './auth';
+import { Database } from '../../drizzle/db';
+
+export function createAuthMiddleware(db: Database): MiddlewareHandler {
+  const auth = initAuth(db);
+
+  return async (c: Context, next) => {
+    const sessionId = auth.getSessionIdFromCookie(c);
+    if (!sessionId) {
+      c.set('user', null);
+      return next();
+    }
+
+    try {
+      const session = await auth.getSession(sessionId);
+      if (!session) {
+        auth.clearSessionCookie(c);
+        c.set('user', null);
+        return next();
+      }
+
+      const user = await auth.adapter.getUserById(session.userId);
+      if (!user) {
+        auth.clearSessionCookie(c);
+        c.set('user', null);
+        return next();
+      }
+
+      // Set user in context
+      c.set('user', user);
+    } catch (error) {
+      console.error('Auth middleware error:', error);
+      c.set('user', null);
+    }
+
+    return next();
+  };
+}
+
+// Middleware to require authentication
+export function requireAuth(): MiddlewareHandler {
+  return async (c: Context, next) => {
+    const user = c.get('user');
+    if (!user) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    
+    return next();
+  };
+}

--- a/backend/src/modules/auth/routes.ts
+++ b/backend/src/modules/auth/routes.ts
@@ -1,0 +1,147 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import { initAuth } from './auth';
+import { Database } from '../../drizzle/db';
+
+// Define validation schemas
+const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  name: z.string().optional(),
+});
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
+
+// Create auth routes
+export function createAuthRoutes(db: Database) {
+  const auth = initAuth(db);
+  const authRoutes = new Hono();
+
+  // Register route
+  authRoutes.post('/register', zValidator('json', registerSchema), async (c) => {
+    const { email, password, name } = c.req.valid('json');
+
+    try {
+      // Check if user already exists
+      const existingUser = await auth.adapter.getUserByEmail(email);
+      if (existingUser) {
+        return c.json({ error: 'User already exists' }, 400);
+      }
+
+      // Create user
+      const user = await auth.createUser({
+        email,
+        password,
+        name,
+      });
+
+      // Create session
+      const session = await auth.createSession({
+        userId: user.id,
+      });
+
+      // Set session cookie
+      auth.setSessionCookie(c, session.id);
+
+      return c.json({ 
+        user: { 
+          id: user.id, 
+          email: user.email, 
+          name: user.name 
+        } 
+      }, 201);
+    } catch (error) {
+      console.error('Registration error:', error);
+      return c.json({ error: 'Failed to register user' }, 500);
+    }
+  });
+
+  // Login route
+  authRoutes.post('/login', zValidator('json', loginSchema), async (c) => {
+    const { email, password } = c.req.valid('json');
+
+    try {
+      // Verify credentials
+      const user = await auth.verifyCredentials({ email, password });
+      if (!user) {
+        return c.json({ error: 'Invalid credentials' }, 401);
+      }
+
+      // Create session
+      const session = await auth.createSession({
+        userId: user.id,
+      });
+
+      // Set session cookie
+      auth.setSessionCookie(c, session.id);
+
+      return c.json({ 
+        user: { 
+          id: user.id, 
+          email: user.email, 
+          name: user.name 
+        } 
+      });
+    } catch (error) {
+      console.error('Login error:', error);
+      return c.json({ error: 'Failed to login' }, 500);
+    }
+  });
+
+  // Logout route
+  authRoutes.post('/logout', async (c) => {
+    try {
+      const sessionId = auth.getSessionIdFromCookie(c);
+      if (sessionId) {
+        await auth.deleteSession(sessionId);
+      }
+      
+      // Clear session cookie
+      auth.clearSessionCookie(c);
+      
+      return c.json({ success: true });
+    } catch (error) {
+      console.error('Logout error:', error);
+      return c.json({ error: 'Failed to logout' }, 500);
+    }
+  });
+
+  // Get current user route
+  authRoutes.get('/me', async (c) => {
+    try {
+      const sessionId = auth.getSessionIdFromCookie(c);
+      if (!sessionId) {
+        return c.json({ user: null }, 401);
+      }
+
+      const session = await auth.getSession(sessionId);
+      if (!session) {
+        auth.clearSessionCookie(c);
+        return c.json({ user: null }, 401);
+      }
+
+      const user = await auth.adapter.getUserById(session.userId);
+      if (!user) {
+        auth.clearSessionCookie(c);
+        return c.json({ user: null }, 401);
+      }
+
+      return c.json({ 
+        user: { 
+          id: user.id, 
+          email: user.email, 
+          name: user.name 
+        } 
+      });
+    } catch (error) {
+      console.error('Get current user error:', error);
+      return c.json({ error: 'Failed to get current user' }, 500);
+    }
+  });
+
+  return authRoutes;
+}

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -3,8 +3,8 @@ main = "src/index.ts"
 compatibility_date = "2023-09-01"
 
 # Add D1 database binding
-# [d1_databases]
-# DATABASE_NAME = { binding = "DB" }
+[d1_databases]
+DB = { binding = "DB" }
 
 # Add KV namespace binding (optional)
 # [[kv_namespaces]]


### PR DESCRIPTION
## Description

This PR implements the backend authentication system as described in Issue #3. It includes:

- Drizzle ORM setup with D1 database
- Schema definitions for users, sessions, papers, and user interests
- BetterAuth integration for authentication
- Auth routes for registration, login, logout, and user info
- Auth middleware for protecting routes

## Changes

- Created database schema using Drizzle ORM
- Set up D1 database configuration in wrangler.toml
- Implemented BetterAuth adapter for Drizzle ORM
- Created authentication routes and middleware
- Added scripts for local database setup and migrations

## Checklist

- [x] Drizzle ORM is configured with D1 database
- [x] Basic schema migrations are set up
- [x] BetterAuth is integrated with our Hono.js app
- [x] Authentication endpoints (register, login, logout) are implemented
- [x] Local development environment setup is documented

## Testing

The authentication system can be tested locally by running:

```bash
cd backend
npm run db:setup  # Set up local D1 database
npm run dev       # Start development server
```

Then use the following endpoints:
- POST /auth/register - Register a new user
- POST /auth/login - Login with email/password
- POST /auth/logout - Logout current user
- GET /auth/me - Get current user info

Closes #3